### PR TITLE
Add documentation and .gem file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ rdoc
 pkg
 .rbenv-version
 *.swp
+*.gem
+doc/
+.yardoc/
 tags


### PR DESCRIPTION
This adds the following to .gitignore:

```
*.gem
doc/
.yardoc/
```
