### PR TITLE
Create Entry::chown and Entry::chown_R

### DIFF
--- a/lib/rush/entry.rb
+++ b/lib/rush/entry.rb
@@ -163,6 +163,35 @@ class Rush::Entry
     Rush::Access.new.from_octal(stat[:mode]).display_hash
   end
 
+
+  # Change entry ownership
+  #
+  # Changes owner and group on the named files (in list) to the user user and the group group. user and group may be an ID (Integer/String) or a name (String). If user or group is nil, this method does not change the attribute.
+  #
+  # @param user [string/integer] The user to own the file
+  # @param group [string/integer] The group to own the file
+  # @param options [hash] the options to pass to FileUtils.chown (eg. 'noop', 'verbose' or 'recursive' )
+  #
+  def chown( user = nil, group = nil, options = {} )
+
+    connection.chown( full_path, user, group, options )
+    self
+
+  end
+
+
+  # Shortcut to Entry::chown to pass the 'recursive' option by default
+  #
+  def chown_R( user = nil, group = nil, options = {} )
+
+    options[ :recursive ] = true
+    chown( user, group, options )
+
+  end
+
+
+
+
   # Destroy the entry.  If it is a dir, everything inside it will also be destroyed.
   def destroy
     connection.destroy(full_path)

--- a/lib/rush/local.rb
+++ b/lib/rush/local.rb
@@ -128,6 +128,24 @@ class Rush::Connection::Local
     access.apply(full_path)
   end
 
+
+  # A frontend for FileUtils::chown
+  #
+  def chown( full_path, user=nil, group=nil, options={} )
+
+    if options[ :recursive ]
+
+      FileUtils.chown_R( user, group, full_path, options )
+
+    else
+
+      FileUtils.chown( user, group, full_path, options )
+
+    end
+
+  end
+
+
   # Fetch the size of a dir, since a standard file stat does not include the
   # size of the contents.
   def size(full_path)
@@ -345,6 +363,7 @@ class Rush::Connection::Local
       when 'index'          then index(params[:base_path], params[:glob]).join("\n") + "\n"
       when 'stat'           then YAML.dump(stat(params[:full_path]))
       when 'set_access'     then set_access(params[:full_path], Rush::Access.from_hash(params))
+      when 'chown'          then chown( params[:full_path], params[:user], params[:group], params[:options])
       when 'size'           then size(params[:full_path])
       when 'processes'      then YAML.dump(processes)
       when 'process_alive'  then process_alive(params[:pid]) ? '1' : '0'

--- a/lib/rush/remote.rb
+++ b/lib/rush/remote.rb
@@ -66,6 +66,10 @@ class Rush::Connection::Remote
 		transmit access.to_hash.merge(:action => 'set_access', :full_path => full_path)
 	end
 
+	def chown( full_path, user = nil, group = nil, options = {} )
+		transmit( :action => 'chown', :full_path => full_path, :user => user, :group => group, :options => options )
+	end
+
 	def size(full_path)
 		transmit(:action => 'size', :full_path => full_path).to_i
 	end

--- a/spec/local_spec.rb
+++ b/spec/local_spec.rb
@@ -85,6 +85,12 @@ describe Rush::Connection::Local do
 		@con.receive(:action => 'size', :full_path => 'full_path').should == "1024"
 	end
 
+	it "receive -> chown( full_path, user, group, options )" do
+		options = { noop: true }
+		@con.should_receive(:chown).with('full_path', 'username', 'groupname', options )
+		@con.receive(:action => 'chown', :full_path => 'full_path', user: 'username', group: 'groupname', options: options)
+	end
+
 	it "receive -> processes" do
 		@con.should_receive(:processes).with().and_return([ { :pid => 1 } ])
 		@con.receive(:action => 'processes').should == YAML.dump([ { :pid => 1 } ])
@@ -253,6 +259,8 @@ describe Rush::Connection::Local do
 		access.should_receive(:apply).with('/some/path')
 		@con.set_access('/some/path', access)
 	end
+
+	it "chown should change the ownership of a file"
 
 	if !RUBY_PLATFORM.match(/darwin/)   # doesn't work on OS X 'cause du switches are different
 		it "size gives size of a directory and all its contents recursively" do


### PR DESCRIPTION
Rush didn't have a method for changing ownership of files and directories. This adds Entry::chown which takes 3 parameters:
user, group and options

It is a simple frontend for FileUtils.chown and chown_R, to integrate their functionality with the Rush syntax.

Currently not very tested. The problem is that tests for this will have to run as sudo usually, because unprivileged you can't do much with chown. Also, I currently didn't have a remote setup which would be practical for testing, so remote testing has not been done at all.

Towards the future I would like to add more sys admin functionality to Rush, so it's not only an interface to filesystem and bash, but also to user management. Obviously a growing number of features would require root access to be used, and thus also to be tested. I will think about a way to create an optional set of tests that will be run only if the specs are being run as root. That way, we can have our tests, but peopl who can't be bothered to run it as root can still run all the other tests.

Btw: I discovered another problem. I wanted to test this at least manually with a remote, so I tried to install mongrel, but that seems to be no longer supported. Mongrel doesn't run after ruby 1.9.1 and seems to be an abandoned project. I think it is appropriate to consider completely redesigning rush, and think of a better way to run commands on the remote. I also proposed some design changes for the filesystem in adamwiggins/rush#21. Today I also discovered [vfs](https://github.com/najamelan/vfs) and vos by alexey petrushkin. This is an interesting design as well, which uses a concept of Drivers, which is better and more extendible that the "connection" rush uses. I'm going to test vfs for a while and then think of a solution. 
